### PR TITLE
Fix IntrinsicMatrix format in cameraParameters

### DIFF
--- a/data/generate_undistort_map_radtan.m
+++ b/data/generate_undistort_map_radtan.m
@@ -39,7 +39,7 @@ if nargin < 3
     batch_size = 1;
 end
 
-K = reshape(cinfo.K, 3, 3)';
+K = reshape(cinfo.K, 3, 3);
 D = cinfo.D;
 rows = cinfo.height;
 cols = cinfo.width;


### PR DESCRIPTION
Hi,
First of all, I would like to thank you for making this code publicly available.  It has been extremely useful in the evaluation of the algorithms we developed in our lab.

The current code inputs the intrinsic matrix in the format K=[[fx,0,cx][,0,fy,cy],[0,0,1]]  to  ``cameraParameters()``. This is incorrect as the function expects the transpose of K (see [official documentation](https://mathworks.com/help/vision/ref/cameraparameters.html)). Consequently, the principal point is not correctly loaded. This patch solves the issue.

Best regards,
Ignacio 